### PR TITLE
Upgraded box to Ubuntu Server 13.10 x64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build.properties
 *.sublime-workspace
 
 # Much credit to http://gitignore.io for many of these
+www/default/vhosts.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cptserver
 =========
 
-A student web development environment using Vagrant, Virtualbox, and Puppet.
+A web development environment using Ubuntu Server 13.10 x86_64, Vagrant, Virtualbox, and Puppet.
 
 Virtualbox is software that lets you create virtual machines, allowing you to run another operating system in a sandbox. Vagrant is used to customize, load, and access that virtual machine. Once it's running, Puppet is used to manage the software on the virtual machine.  Puppet makes sure things like Apache and MySQL are installed, running as a service, configured properly, and restarted when necessary.
 
@@ -11,6 +11,7 @@ Features
 --------
 
 * It uses a single config file for everything. No need to dig into Puppet code to customize.
+* Chef and Puppet provisioners are pre-installed.
 * It adds a repository that will give you the latest PHP (5.5+) and Apache (2.4+).
 * It installs phpMyAdmin for you so that you can manage databases.
 * It also configures MySQL so that you can use local DB software on your computer, like MySQL Workbench.
@@ -23,15 +24,20 @@ Installation
 1. First, install Virtualbox, then Vagrant. You don't need Puppet on your host computer; it will exist on the linux virtual machine.
  * Virtualbox - https://www.virtualbox.org/wiki/Downloads
  * Vagrant - http://www.vagrantup.com/
+
 2. Next, download this repository. You could just download the .zip file and extract it where you keep your work, but cloning with Git is preferred. If you haven't learned Git yet, you really should.
  * Git - http://git-scm.com/downloads
  * Go to your project folder (on Windows, it's probably something like 'C:\Users\Scott\Documents\'), open a terminal/command promt, and type `git clone https://github.com/pigeontech/cptserver.git`.
  * This creates a copy on your computer, like 'C:\Users\Scott\Documents\cptserver\'.  Go into that folder.
+
 3. Open the config/config.yaml file in a text editor, and change anything that you feel needs changed. Right now, the only thing that probably matters is the mysql password. You can add virtual hosts later.  Also, if your computer is already using port 80, like if you run a media server to stream movies to your TV, you might need to change port 80 to something else, like 8080.
+
 4. Open a terminal in the repository folder. If the terminal is still open from the Git step, just type `cd cptserver`.
+
 5. Now type `vagrant up`.
  * It will streamline the entire process for you, from creating the virtual machine to installing PHP and its modules.
  * The first time you run it, it will be slow, because it must download and install a linux box, which is a few hundred mb.
+ 
 6. It's ready. Inside the `www/default/` folder is a sample website. Open your browser and go to `http://localhost` and see if it works. Check out `http://localhost/phpmyadmin` as well, and try logging with the username `root` and the password you set in the config.yaml file.  If you changed the port, these URLs would look like `http://localhost:8080` and `http://localhost:8080/phpmyadmin`.
 
 Virtual Hosts
@@ -70,6 +76,7 @@ Composer
 Composer is a dependency manager for common libraries, such as the popular Laravel framework, or the PHPUnit testing library.  It will automatically download the latest/specified version of them, as well as any dependencies that they rely on.  It will then create an autoload.php file, which you include into your actual project to load the library and dependencies.  Composer, like Git, is one of those technologies that separates the new school from the old school.  Don't get left behind! It's more important than ever for web developers to become familiar with these command line tools.
 
 1. Log in via `vagrant ssh` and navigate to your website folder, such as `cd /var/www/mywebsite`.
+
 2. Create a `composer.json` file in the same place containing the following:
 
  ```
@@ -81,6 +88,7 @@ Composer is a dependency manager for common libraries, such as the popular Larav
  ```
 
  Don't make things difficult. You don't have to use Vi or Nano to create and edit this file. You can do this step on your normal computer with Sublime Text, Notepad, etc. Remember that the www folder is shared between your computer and the vm. Changes to one happen to both. That's the whole point of using Vagrant!
+
 3. Back to the terminal, type `composer install`. This will create a `vendor` folder, download all of the software packages you specified in the json file, and also download their dependencies. For example, if you specify PHPUnit as above, your project and vendor folder will look like this:
 
  ```
@@ -99,7 +107,9 @@ Composer is a dependency manager for common libraries, such as the popular Larav
  -- autoload.php
  ```
 4. Now in your index.php file, you'd put something like `require 'vendor/autoload.php';`.
+
 5. Keep in mind that you need to do all of these steps for each website you build. Composer is dependency managment on a per project basis. So if you create another website, like `\var\www\lolcatpics`, it will need its own composor.json, and you'll need to run `composer install` in that directory, and a vendor folder will be created.
+
 6. Visit the following websites to learn more about fitting these tools into your workflow:
  * http://daylerees.com/composer-primer
  * https://www.digitalocean.com/community/articles/how-to-install-and-use-composer-on-your-vps-running-ubuntu 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-cptserver
-=========
+Vagrant - LAMP (Linux Apache MySQL PHP)
+========================================
 
 A web development environment using Ubuntu Server 13.10 x86_64, Vagrant, Virtualbox, and Puppet.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
 	config.vm.hostname = vconfig['vagrant']['vm_hostname']
 	config.vm.network "forwarded_port", guest: 80, host: vconfig['vagrant']['box_port']
 	config.vm.network "forwarded_port", guest: 3306, host: vconfig['mysql']['port']
-	config.vm.synced_folder vconfig['vagrant']['vm_webroot'], vconfig['vagrant']['vm_docroot'], :owner => "vagrant", :group => "www-data", :mount_options => ["dmode=777","fmode=777"]
+	config.vm.synced_folder vconfig['vagrant']['vm_webroot'], vconfig['vagrant']['vm_docroot'], type: 'nfs', :owner => "vagrant", :group => "www-data", :mount_options => ["dmode=777","fmode=777"]
   
 	####################################
 	### VirtualBox Provider

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 vagrant:
-  box: precise32
-  box_url: http://files.vagrantup.com/precise32.box
+  box: parallels/ubuntu-13.10
+  box_url: https://vagrantcloud.com/parallels/ubuntu-13.10
   box_port: 80
   box_ip: 10.0.0.123
   ssh_shell: bash -c 'BASH_ENV=/etc/profile exec bash'
@@ -20,7 +20,7 @@ syspackages:
   - curl
   - php5-dev
   - php-pear
-  - libyaml-dev  
+  - libyaml-dev
 apachemodules:
   - rewrite
 mysql:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -53,7 +53,7 @@ xdebug:
 rewrite:
   Directory: /var/www/
   Options: Indexes FollowSymLinks MultiViews
-  AllowOverride: FileInfo
+  AllowOverride: Options
   Order: allow,deny
   Allow: from all
 vhosts:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,11 +2,11 @@ vagrant:
   box: parallels/ubuntu-13.10
   box_url: https://vagrantcloud.com/parallels/ubuntu-13.10
   box_port: 80
-  box_ip: 10.0.0.123
+  box_ip: 192.168.56.100
   ssh_shell: bash -c 'BASH_ENV=/etc/profile exec bash'
   ssh_username: vagrant
   vm_name: cptserver
-  vm_memory: 512
+  vm_memory: 1024
   vm_cpu: 80
   vm_webroot: www
   vm_docroot: /var/www

--- a/config/puppet/manifests/default.pp
+++ b/config/puppet/manifests/default.pp
@@ -18,6 +18,14 @@ exec
 	command => "apt-get update",
 }
 
+# Install Software-Properties package. Needed for U13.10
+package
+{
+	"software-properties-common":
+	name => "software-properties-common",
+	ensure => latest,
+}
+
 # Install system packages
 package
 {

--- a/config/shell/default.sh
+++ b/config/shell/default.sh
@@ -1,1 +1,3 @@
 cat /vagrant/config/shell/info.txt
+sudo apt-get install -y puppet-common
+cat /vagrant/config/shell/info.txt

--- a/www/default/index.php
+++ b/www/default/index.php
@@ -10,10 +10,13 @@
 <p>
 	The installation was successful!
 </p>
+<p>You can also log into your server through SSH with any client you like.</p>
+<p>Username and password is 'vagrant', and the host is 127.0.0.1</p>
+<p>You can upgrade to Ubuntu 14.x when you log in through SSH, but you will then need to manually modify server settings again.</p>
 <h3>Useful Links</h3>
 <ul>
 	<li><a href="phpinfo.php">PHP Info</a> - View information about the software on this server.</li>
-	<li><a href="phpmyadmin">phpMyAdmin</a> - Create and manage databases.</li>
+	<li><a href="phpmyadmin">phpMyAdmin</a> - Create and manage databases. (Username: root | Password: vagrant)</li>
 </ul>
 
 <h3>Your Websites</h3>

--- a/www/default/phpinfo.php
+++ b/www/default/phpinfo.php
@@ -1,3 +1,127 @@
-<?php
- phpinfo();
-?>
+<?php 
+   ob_start(); 
+   phpinfo(); 
+   $Ausgabe = ob_get_contents(); 
+   ob_end_clean(); 
+   preg_match_all("=<body[^>]*>(.*)</body>=siU", $Ausgabe, $a); 
+   $phpinfo = $a[1][0]; 
+   $phpinfo = str_replace( 'width="600"', 'width="750"', $phpinfo ); 
+   $phpinfo = str_replace( 'border="0" cellpadding', 'class="x" border="0" cellpadding', $phpinfo ); 
+   $phpinfo = str_replace( '<td>', '<td><div class="tt">', $phpinfo ); 
+   $phpinfo = str_replace( '<td class="e">', '<td class="e"><div class="te">', $phpinfo ); 
+   $phpinfo = str_replace( '<td class="v">', '<td class="v"><div class="tv">', $phpinfo ); 
+   $phpinfo = str_replace( '</td>', '</div></td>', $phpinfo ); 
+
+?> 
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"> 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de"> 
+   <head> 
+   <title>phpinfo()</title> 
+<style type="text/css"> 
+<!-- 
+body { 
+   margin: 10px 10px 10px; 
+   background-color: #fff; 
+   color: #000000; 
+} 
+body,p,h1,h2,h3,h4,h5,h6,td,ul,ol,li,div,address,blockquote,nobr { 
+   font-size: 11px; 
+   font-family: Verdana, Tahoma, Arial Helvetica, Geneva, Sans-Serif; 
+   font-weight: normal; 
+} 
+pre { 
+   margin: 0px; 
+   font-family: monospace; 
+} 
+a:link { 
+   color: #000099; 
+   text-decoration: none; 
+} 
+a:hover { 
+   text-decoration: underline; 
+} 
+table { 
+   border-collapse: collapse; 
+} 
+.center { 
+   text-align: center; 
+} 
+.center table { 
+   margin-left: auto; 
+   margin-right: auto; 
+   text-align: left; 
+} 
+.center th { 
+   text-align: center !important; 
+} 
+td, th { 
+   border: 1px solid #a2aab8; 
+   vertical-align: baseline; 
+} 
+h1 { 
+   font-size: 16px; 
+   font-weight: bold; 
+} 
+h2 { 
+   font-size: 14px; 
+   font-weight: bold; 
+} 
+.p { 
+   text-align: left; 
+} 
+.e { 
+   background-color: #e3e3ea; 
+   font-weight: bold; 
+   color: #000000; 
+} 
+.h { 
+   background-color: #a2aab8; 
+   font-weight: bold; 
+   color: #000000; 
+   font-size: 11px; 
+} 
+.v { 
+   background-color: #efeff4; 
+   color: #000000; 
+} 
+i { 
+   color: #666666; 
+   background-color: #cccccc; 
+} 
+img { 
+   float: right; 
+   border: solid 0px #1a1a1a; 
+   #background-color:#9999cc; 
+} 
+hr { 
+   width: 750px; 
+   background-color: #cccccc; 
+   border: 0px; 
+   height: 1px; 
+   color: #1a1a1a; 
+} 
+.x { 
+   width: 750px; 
+} 
+.tt { 
+} 
+.te { 
+   font-weight:bold; 
+} 
+.tv { 
+   position:relative; 
+   overflow:auto; 
+} 
+//--> 
+</style> 
+   </head> 
+
+<body> 
+<?php 
+$path = getcwd();
+$domain = $_SERVER['HTTP_HOST'];
+echo "<p align='center'><b>This Is Your Absolute Path:</b> $path <b>on</b> <a href='http://$domain'>$domain/</a></p>";
+ echo $phpinfo; 
+?> 
+</body> 
+</html


### PR DESCRIPTION
Switched base box from Ubuntu 12.04 to Ubuntu Server 13.10 x86_64
(https://vagrantcloud.com/parallels/ubuntu-13.10). Base box is
automatically downloaded from Vagrantcloud.com to your local host.

Also added package dependency, installed package
software-properties-common. Which was needed in U13.10 to enable further
installation of LAMP-stack.

Puppet-common package is now installed from the shell-script, and Chef
is available inside the box, but Chef needs to be configured first.

Modified phpinfo-page with CSS to make it loo pretty! :)
Added some extra useful info in the default index.php-file.