### PR TITLE
Changed config loading to work from any subdirectory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,9 @@
 ### Load Configuration Variables
 ####################################
 require 'yaml'
-$vconfig = YAML::load_file("config/config.yaml")
+
+dir = File.dirname(File.expand_path(__FILE__))
+$vconfig = YAML::load_file("#{dir}/config/config.yaml")
 
 # Handle directory
 def getDirectory(directory, tabs)


### PR DESCRIPTION
Kept trying to run vagrant commands from inside my virtual host subdirectories and it wasn't working because vagrant couldn't find the config.yaml file. Added a couple of lines to fix that.
